### PR TITLE
use giscus to allow comments

### DIFF
--- a/themes/lean_theme/templates/base.tmpl
+++ b/themes/lean_theme/templates/base.tmpl
@@ -16,6 +16,22 @@
         {{ header.html_header() }}
         <main id="content">
             {% block content %}{% endblock %}
+
+        <script src="https://giscus.app/client.js"
+            data-repo="leanprover-community/blog"
+            data-repo-id="MDEwOlJlcG9zaXRvcnkzOTM3OTE1ODU="
+            data-category="Announcements"
+            data-category-id="DIC_kwDOF3jIYc4CQntU"
+            data-mapping="title"
+            data-strict="1"
+            data-reactions-enabled="1"
+            data-emit-metadata="0"
+            data-input-position="bottom"
+            data-theme="light"
+            data-lang="en"
+            crossorigin="anonymous"
+            async>
+        </script>
         </main>
         {{ footer.html_footer() }}
     </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4967469/182885969-87822cf1-2112-438b-9cb6-607911be787c.png)

[Giscus](https://giscus.app/) the GitHub [discussions](https://github.com/leanprover-community/blog/discussions) feature and some javascript to allow comments on our otherwise static blog. Commenters log in through GitHub (they need to authorize the giscus app first).