### PR TITLE
post about recent additions to mathlib about abelian categories

### DIFF
--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -1,0 +1,29 @@
+---
+author: 'Markus Himmel and Joël Riou'
+category: 'New in mathlib'
+date: 2025-02-28 11:36:00 UTC+01:00
+description: ''
+has_math: true
+link: ''
+slug: abelian-categories
+tags: ''
+title: Theorems about abelian categories
+type: text
+---
+
+...
+
+<!-- TEASER_END -->
+
+# The small object argument
+
+# Grothendieck abelian categories have enough injectives
+
+
+# Freyd-Mitchell
+
+# Gabriel-Popescu
+
+
+
+

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -1,7 +1,7 @@
 ---
 author: "Markus Himmel and Joël Riou"
 category: "New in mathlib"
-date: 2025-02-28 11:36:00 UTC+01:00
+date: 2025-06-17 11:15:00 UTC+02:00
 description: ""
 has_math: true
 link: ""

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -1,12 +1,12 @@
 ---
-author: 'Markus Himmel and Joël Riou'
-category: 'New in mathlib'
+author: "Markus Himmel and Joël Riou"
+category: "New in mathlib"
 date: 2025-02-28 11:36:00 UTC+01:00
-description: ''
+description: ""
 has_math: true
-link: ''
+link: ""
 slug: abelian-categories
-tags: ''
+tags: ""
 title: Theorems about abelian categories
 type: text
 ---
@@ -29,12 +29,14 @@ that a morphism $i : A \to B$ has the left lifting property with
 respect to $p : X \to Y$ if for any commutative square as below
 there exists a morphism $B \to X$ which makes both triangles commute.
 
-$$\require{AMScd}
+$$
+\require{AMScd}
 \begin{CD}
 A @>>> X\\\\
 @VV{i}V @VV{p}V \\\\
 B @>>> Y
-\end{CD}$$
+\end{CD}
+$$
 
 If this holds, we would also say that $p$ has the right lifting property
 with respect to $i$.
@@ -64,23 +66,27 @@ The basic construction for the small object argument is as follows. If $X \to Y$
 is a morphism, and $I$ is a family of morphisms $f_i : A_i \to B_i$, we consider all
 commutative squares:
 
-$$\require{AMScd}
+$$
+\require{AMScd}
 \begin{CD}
 A_i @>>> X\\\\
 @VV{f_i}V @VV{p}V \\\\
 B_i @>>> Y
-\end{CD}$$
+\end{CD}
+$$
 
 We may define $SA$ to be the coproduct (indexed by all these squares) of the objects $A_i$
 and $SB$ to be the coproduct of the objects $B_i$.
 We may form the following pushout square:
 
-$$\require{AMScd}
+$$
+\require{AMScd}
 \begin{CD}
 SA @>>> X\\\\
 @VVV @VVV \\\\
 SB @>>> Z
-\end{CD}$$
+\end{CD}
+$$
 
 Thus, we get a factorization $X \to Z \to Y$ such that for any commutative square as above,
 we may not necessarily get a lifting $B_i \to X$, but at least, we obtain a tautological morphism
@@ -104,7 +110,7 @@ this result was generalized by Grothendieck.
 
 # Grothendieck abelian categories have enough injectives
 
-One of the results in the paper *Sur quelques points d'algèbre homologique* (*Tohoku Math. J.* (2), 9, 1957)
+One of the results in the paper _Sur quelques points d'algèbre homologique_ (_Tohoku Math. J._ (2), 9, 1957)
 by Alexander Grothendieck is that any Grothendieck abelian category has enough injectives.
 An abelian category $C$ is a Grothendieck abelian category if it satisfies certain axioms introduced
 in this paper: we assume that filtered colimits are exact and that there exists a generator $G$
@@ -149,14 +155,15 @@ proofs that chase elements around to no longer mention elements, this can be ann
 ## Partial results
 
 There are several techniques that enable elementwise reasoning in abelian categories.
-The first one is called *pseudoelements*. It appears in Mac Lane's *Categories for the Working Mathematician*
-and in Borceux' *Handbook of Categorical Algebra* and it entered mathlib in August of 2020.
+The first one is called _pseudoelements_. It appears in Mac Lane's _Categories for the Working Mathematician_
+and in Borceux' _Handbook of Categorical Algebra_ and it entered mathlib in August of 2020.
 
 Given an object $X$ of an abelian category $C$, we can consider the collection of morphisms with codomain $X$.
 We say that two morphisms $f_1 : P_1 \to X$ and $f_2 : P_2 \to X$ are equivalent if there is an object $Q$
 and epimorphisms $Q \to P_1$ and $Q \to P_2$ making the diagram
 
-$$\require{AMScd}
+$$
+\require{AMScd}
 \begin{CD}
 Q @>>> P_1\\\\
 @VVV @VVf_1V\\\\
@@ -214,13 +221,13 @@ of enough injectives in Grothendieck abelian categories), so our approach will b
 
 There are several candidates for $D$ which appear in the literature.
 
-* Freyd's *Abelian Categories* takes $D$ to be the opposite of the category of left-exact functors from $C$ to the category of abelian groups.
-Properties of $D$ are established mostly using ad-hoc arguments. Note that it is not obvious that $D$ is abelian, since $D$ does not contain
-*all* functors from $C$ to $\mathsf{Ab}$.
-* The proof sketched in the Stacks project takes $D$ to be the opposite of a category of abelian sheaves for a certain Grothendieck topology which is
-inspired by Bergman's refinements. Many properties of $D$ are proved by transporting them along the sheafification adjunction.
-* The proof given in Kashiwara and Schapira's *Categories and Sheaves* takes $D$ to be the opposite of the category of ind-objects of $C^{\mathsf{op}}$
-(this is the category of pro-objects of $C$). Here, we infer many properties from properties of the category of types.
+- Freyd's _Abelian Categories_ takes $D$ to be the opposite of the category of left-exact functors from $C$ to the category of abelian groups.
+  Properties of $D$ are established mostly using ad-hoc arguments. Note that it is not obvious that $D$ is abelian, since $D$ does not contain
+  _all_ functors from $C$ to $\mathsf{Ab}$.
+- The proof sketched in the Stacks project takes $D$ to be the opposite of a category of abelian sheaves for a certain Grothendieck topology which is
+  inspired by Bergman's refinements. Many properties of $D$ are proved by transporting them along the sheafification adjunction.
+- The proof given in Kashiwara and Schapira's _Categories and Sheaves_ takes $D$ to be the opposite of the category of ind-objects of $C^{\mathsf{op}}$
+  (this is the category of pro-objects of $C$). Here, we infer many properties from properties of the category of types.
 
 It can be shown that all of these choices for $D$ are actually equivalent as categories, but nonetheless the perspective one takes significantly
 changes the flavor of the resulting proof.
@@ -278,15 +285,27 @@ this step has no effect.
 At the beginning of the project, we were thinking about how one would go about providing infrastructure or even automation to construct a small category to apply
 the embedding theorem to, but it looks like something like this will not be needed, which is nice.
 
-# Gabriel-Popescu
+# The Gabriel-Popescu theorem
 
-# Future work
+The Gabriel-Popescu theorem states that if $C$ is a Grothendieck abelian category and $G$ is a generator of $C$, then the hom-functor
+$\operatorname{Hom}(G, {-})$ taking values in $\operatorname{End}(G)^{\mathsf{op}}$-modules is fully faithful and has an exact left-adjoint.
+This looks similar to the embedding theorem for co-Grothendieck abelian categories discussed above as part of the Freyd-Michell embedding
+theorem.
 
+However, the two results are quite different in nature. The Freyd-Mitchell embedding theorem, while useful, does not _really_ tell you anything
+about $C$ on a structural level. In other words, the Freyd-Mitchell embedding theorem does not tell you which of the properties of the
+category of $R$-modules are inherited by $C$. On the other hand, the Gabriel-Popescu theorem exhibits $C$ as an exact reflective subcategory of a category
+of modules, and this means that Grothendieck abelian categories inherit many interesting properties of the category of $R$-modules.
 
+Following a simple proof given by Barry Mitchell in 1981, Markus Himmel has added the Gabriel-Popescu theorem stated in terms of adjoint functors
+to mathlib in [PR 22733](https://github.com/leanprover-community/mathlib4/pull/22733) in March 2025. Meanwhile, Joël Riou has been working on
+giving the relevant definitions of Serre quotients necessary to restate the result in terms of localization functors. This in turn will
+pave the way for a deeper study of the structure of Grothendieck abelian categories which will be useful when dealing with size issues in the
+general setup of homological algebra in abelian categories.
 
-[^1]: In fact, when Markus Himmel formalized the development of pseudoelements in Borceux' *Handbook of Categorical Algebra*,
-he was unable to follow one of the results claiming that pseudoelements interact favorably with pullbacks. This result
-later would have been useful in the Liquid Tensor Experiment, leading to a [MathOverflow discussion](https://mathoverflow.net/a/419951/7845)
-and the subsequent [formalization of a counterexample](https://github.com/leanprover-community/mathlib3/pull/13387)
-by Riccardo Brasca.
-
+[^1]:
+    In fact, when Markus Himmel formalized the development of pseudoelements in Borceux' _Handbook of Categorical Algebra_,
+    he was unable to follow one of the results claiming that pseudoelements interact favorably with pullbacks. This result
+    later would have been useful in the Liquid Tensor Experiment, leading to a [MathOverflow discussion](https://mathoverflow.net/a/419951/7845)
+    and the subsequent [formalization of a counterexample](https://github.com/leanprover-community/mathlib3/pull/13387)
+    by Riccardo Brasca.

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -11,16 +11,130 @@ title: Theorems about abelian categories
 type: text
 ---
 
-...
+Two significant results about abelian categories have recently been
+added to mathlib. The first is that any Grothendieck
+abelian category has enough injectives, and it follows from a
+general construction known as the small object argument. The second
+is the Freyd-Mitchell theorem which states that any abelian
+category admits a fully faithful exact functor to a category
+of modules.
 
 <!-- TEASER_END -->
 
 # The small object argument
 
+The small object argument is about constructing morphisms that have
+certain lifting properties. In a category `C`, we shall say
+that a morphism `i : A ⟶ B` has the left lifting property with
+respect to `p : X ⟶ Y` if for any commutative square as below
+there exists a morphism `B ⟶ X` which makes both triangles commute.
+```
+A --> X
+|i    |p
+v     v
+B --> Y
+```
+If this holds, we would also say that `p` has the right lifting property
+with respect to `i`.
+
+This notion is important in homotopical algebra. For example, a morphism `p : X ⟶ Y`
+of simplicial sets is a fibration if and only if it has the right
+lifting property with respect to horn inclusions `Λ[n + 1, i] ⟶ Δ[n + 1]`.
+In particular, a simplicial set `X` is a Kan complex if the map
+`X ⟶ Δ[0]` to the final object is a fibration, which means that any
+morphism `Λ[n + 1, i] ⟶ X` can be extended to a morphism `Δ[n + 1] ⟶ X`.
+
+Similarly, in homological algebra, if `X` is an object in an abelian category `C`,
+`X` is an injective object if and only if the map `X ⟶ 0` to the zero object
+has the right lifting property with respect to all monomorphisms `A ⟶ B` in `C`,
+i.e. when any morphism `A ⟶ X` can be extended to a morphism `B ⟶ X`.
+
+The small object argument involves a "set" of morphisms `I` in the category `C`.
+Under certain technical assumptions, which are packaged in a type class `HasSmallObjectArgument I`,
+any morphism `X ⟶ Y` in `C` can be factored as `X ⟶ Z ⟶ Y` where `Z ⟶ Y` has
+the right lifting property with respect to all the morphisms in `I` and
+`X ⟶ Z` is a transfinite composition of morphisms that are built up from `I`
+in a certain way (technically, these morphisms are pushouts of coproducts
+of morphisms in `I`). Moreover, this factorization is functorial in the morphism
+`X ⟶ Y`.
+
+The basic construction for the small object argument is as follows. If `X ⟶ Y`
+is a morphism, and `I` is a family of morphisms `f i : A i ⟶ B i`, we consider all
+commutative squares:
+```
+A i --> X
+|f i    |p
+v       v
+B i --> Y
+```
+We may define `SA` to be the coproduct (indexed by all these squares) of the objects `A i`
+and `SB` to be the coproduct of the objects `B i`.
+We may form the following pushout square:
+```
+SA --> X
+|      |
+v      v
+SB --> Z
+```
+Thus, we get a factorization `X ⟶ Z ⟶ Y` such that for any commutative square as above,
+we may not necessarily get a lifting `B i ⟶ X`, but at least, we obtain a tautological morphism
+ `B i ⟶ Z`.
+Then, the idea is to iterate this construction (applying it again to the morphism `Z ⟶ Y`, etc.)
+and pass to the colimit. Iterating over the natural numbers `ℕ` is not always enough:
+we actually need to do transfinite induction over a suitably chosen ordinal.
+The most significant part of the formalization was about such constructions by transfinite induction
+in categories, and in order to phrase certain result the structure
+[TransfiniteCompositionOfShape](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.html#CategoryTheory.TransfiniteCompositionOfShape) expressing that a morphism
+is a transfinite composition played an important role.
+
+The small object argument entered mathlib after a series of pull requests by Joël Riou
+(see [PR #20245](https://github.com/leanprover-community/mathlib4/pull/20245) and
+[CategoryTheory.SmallObject.Basic](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/SmallObject/Basic.html)). This result was also formalized in Lean 3 in a pioneering work by Reid Barton.
+
+The small object argument is often attributed to Quillen, but it originates in
+the construction of injective resolutions in categories of modules by Baer,
+and later by Cartan-Eilenberg, and as we shall see in the next section,
+this result was generalized by Grothendieck.
+
 # Grothendieck abelian categories have enough injectives
 
+One of the results in the paper *Sur quelques points d'algèbre homologique* (*Tohoku Math. J.* (2), 9, 1957)
+by Alexander Grothendieck is that any Grothendieck abelian category has enough injectives.
+An abelian category `C` is a Grothendieck abelian category if it satisfies certain axioms introduced
+in the aformentioned paper: we assume that filtered colimits are exact and that there exists a generator `G`
+(any object in `C` is a quotient of a coproduct of copies of `G`).
+Under these assumptions, we would like to show that `C` has enough injectives, which means
+that any object `X` of `C` embeds into an injective object `I`.
+In other words, we would like to show that the morphism `X ⟶ 0` can be factored
+as `X ⟶ I ⟶ 0` where `X ⟶ I` is a monomorphism and `I` is injective,
+i.e. `I ⟶ 0` has the right lifting property with respect to all monomorphisms.
+
+This result is a consequence of the small object argument. Indeed, we construct a set of morphisms
+`generatingMonomorphisms G` (which consists of the inclusions of all subobjects of the generator `G`)
+such that the right lifting property with respect to all monomorphisms is equivalent to the
+right lifting property with respect to this set `generatingMonomorphisms G`. It is quite technical
+to verify the assumptions that are required in order to apply the small object argument to this
+set of morphisms, but once we have it, we get the expected factorization `X ⟶ I ⟶ 0`
+where `I` is injective and `X ⟶ I` is a monomorphism (because monomorphisms are stable under
+pushouts and transfinite compositions).
+
+The formalization appears in the file
+[Abelian.GrothendieckCategory.EnoughInjectives](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.html)
+and it entered mathlib in [PR #20079](https://github.com/leanprover-community/mathlib4/pull/20079) after a series
+of pull requests by Joël Riou.
+
+The existence of enough injectives in Grothendieck abelian categories is an
+important tool in homological algebra. In particular, this applies to
+categories of abelian sheaves over a Grothendieck site, and in the future,
+it shall be used in order to construct right derived functors and to
+study cohomology theories.
+
+This result is also one of the key ingredients in the proof of the
+Freyd-Mitchell embedding theorem.
 
 # Freyd-Mitchell
+
+--[PR #22222](https://github.com/leanprover-community/mathlib4/pull/22222)
 
 # Gabriel-Popescu
 

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -24,72 +24,78 @@ of modules.
 # The small object argument
 
 The small object argument is about constructing morphisms that have
-certain lifting properties. In a category `C`, we shall say
-that a morphism `i : A ⟶ B` has the left lifting property with
-respect to `p : X ⟶ Y` if for any commutative square as below
-there exists a morphism `B ⟶ X` which makes both triangles commute.
-```
-A --> X
-|i    |p
-v     v
-B --> Y
-```
-If this holds, we would also say that `p` has the right lifting property
-with respect to `i`.
+certain lifting properties. In a category $C$, we shall say
+that a morphism $i : A \to B$ has the left lifting property with
+respect to $p : X \to Y$ if for any commutative square as below
+there exists a morphism $B \to X$ which makes both triangles commute.
 
-This notion is important in homotopical algebra. For example, a morphism `p : X ⟶ Y`
+$$\require{AMScd}
+\begin{CD}
+A @>>> X\\\\
+@VV{i}V @VV{p}V \\\\
+B @>>> Y
+\end{CD}$$
+
+If this holds, we would also say that $p$ has the right lifting property
+with respect to $i$.
+
+This notion is important in homotopical algebra. For example, a morphism $p : X \to Y$
 of simplicial sets is a fibration if and only if it has the right
-lifting property with respect to horn inclusions `Λ[n + 1, i] ⟶ Δ[n + 1]`.
-In particular, a simplicial set `X` is a Kan complex if the map
-`X ⟶ Δ[0]` to the final object is a fibration, which means that any
-morphism `Λ[n + 1, i] ⟶ X` can be extended to a morphism `Δ[n + 1] ⟶ X`.
+lifting property with respect to horn inclusions $Λ[n + 1, i] \to Δ[n + 1]$.
+In particular, a simplicial set $X$ is a Kan complex if the map
+$X \to Δ[0]$ to the final object is a fibration, which means that any
+morphism $Λ[n + 1, i] \to X$ can be extended to a morphism $Δ[n + 1] \to X$.
 
-Similarly, in homological algebra, if `X` is an object in an abelian category `C`,
-`X` is an injective object if and only if the map `X ⟶ 0` to the zero object
-has the right lifting property with respect to all monomorphisms `A ⟶ B` in `C`,
-i.e. when any morphism `A ⟶ X` can be extended to a morphism `B ⟶ X`.
+Similarly, in homological algebra, if $X$ is an object in an abelian category $C$,
+$X$ is an injective object if and only if the map $X \to 0$ to the zero object
+has the right lifting property with respect to all monomorphisms $A \to B$ in $C$,
+i.e. when any morphism $A \to X$ can be extended to a morphism $B \to X$.
 
-The small object argument involves a "set" of morphisms `I` in the category `C`.
-Under certain technical assumptions, which are packaged in a type class `HasSmallObjectArgument I`,
-any morphism `X ⟶ Y` in `C` can be factored as `X ⟶ Z ⟶ Y` where `Z ⟶ Y` has
-the right lifting property with respect to all the morphisms in `I` and
-`X ⟶ Z` is a transfinite composition of morphisms that are built up from `I`
+The small object argument involves a "set" of morphisms $I$ in the category $C$.
+Under certain technical assumptions, which are packaged in a type class [`HasSmallObjectArgument I`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/SmallObject/Basic.html#CategoryTheory.MorphismProperty.HasSmallObjectArgument),
+any morphism $X \to Y$ in $C$ can be factored as $X \to Z \to Y$ where $Z \to Y$ has
+the right lifting property with respect to all the morphisms in $I$ and
+$X \to Z$ is a transfinite composition of morphisms that are built up from $I$
 in a certain way (technically, these morphisms are pushouts of coproducts
-of morphisms in `I`). Moreover, this factorization is functorial in the morphism
-`X ⟶ Y`.
+of morphisms in $I$). Moreover, this factorization is functorial in the morphism
+$X \to Y$.
 
-The basic construction for the small object argument is as follows. If `X ⟶ Y`
-is a morphism, and `I` is a family of morphisms `f i : A i ⟶ B i`, we consider all
+The basic construction for the small object argument is as follows. If $X \to Y$
+is a morphism, and $I$ is a family of morphisms $f_i : A_i \to B_i$, we consider all
 commutative squares:
-```
-A i --> X
-|f i    |p
-v       v
-B i --> Y
-```
-We may define `SA` to be the coproduct (indexed by all these squares) of the objects `A i`
-and `SB` to be the coproduct of the objects `B i`.
+
+$$\require{AMScd}
+\begin{CD}
+A_i @>>> X\\\\
+@VV{f_i}V @VV{p}V \\\\
+B_i @>>> Y
+\end{CD}$$
+
+We may define $SA$ to be the coproduct (indexed by all these squares) of the objects $A_i$
+and $SB$ to be the coproduct of the objects $B_i$.
 We may form the following pushout square:
-```
-SA --> X
-|      |
-v      v
-SB --> Z
-```
-Thus, we get a factorization `X ⟶ Z ⟶ Y` such that for any commutative square as above,
-we may not necessarily get a lifting `B i ⟶ X`, but at least, we obtain a tautological morphism
- `B i ⟶ Z`.
-Then, the idea is to iterate this construction (applying it again to the morphism `Z ⟶ Y`, etc.)
-and pass to the colimit. Iterating over the natural numbers `ℕ` is not always enough:
+
+$$\require{AMScd}
+\begin{CD}
+SA @>>> X\\\\
+@VVV @VVV \\\\
+SB @>>> Z
+\end{CD}$$
+
+Thus, we get a factorization $X \to Z \to Y$ such that for any commutative square as above,
+we may not necessarily get a lifting $B_i \to X$, but at least, we obtain a tautological morphism
+$B_i \to Z$.
+Then, the idea is to iterate this construction (applying it again to the morphism $Z \to Y$, etc.)
+and pass to the colimit. Iterating over the natural numbers $ℕ$ is not always enough:
 we actually need to do transfinite induction over a suitably chosen ordinal.
 The most significant part of the formalization was about constructions by transfinite induction
 in categories, and in order to phrase certain result the structure
-[TransfiniteCompositionOfShape](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.html#CategoryTheory.TransfiniteCompositionOfShape) expressing that a morphism
+[`TransfiniteCompositionOfShape`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.html#CategoryTheory.TransfiniteCompositionOfShape) expressing that a morphism
 is a transfinite composition played an important role.
 
 The small object argument entered mathlib after a series of pull requests by Joël Riou
 (see [PR #20245](https://github.com/leanprover-community/mathlib4/pull/20245) and
-[CategoryTheory.SmallObject.Basic](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/SmallObject/Basic.html)). This result was also formalized in Lean 3 in a pioneering work by Reid Barton.
+[`CategoryTheory.SmallObject.Basic`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/SmallObject/Basic.html)). This result was also formalized in Lean 3 in a pioneering work by Reid Barton.
 
 The small object argument is often attributed to Quillen, but it originates in
 the construction of injective resolutions in categories of modules by Baer,
@@ -100,26 +106,26 @@ this result was generalized by Grothendieck.
 
 One of the results in the paper *Sur quelques points d'algèbre homologique* (*Tohoku Math. J.* (2), 9, 1957)
 by Alexander Grothendieck is that any Grothendieck abelian category has enough injectives.
-An abelian category `C` is a Grothendieck abelian category if it satisfies certain axioms introduced
-in this paper: we assume that filtered colimits are exact and that there exists a generator `G`
-(any object in `C` is a quotient of a coproduct of copies of `G`).
-Under these assumptions, we would like to show that `C` has enough injectives, which means
-that any object `X` of `C` embeds into an injective object `I`.
-In other words, we would like to show that the morphism `X ⟶ 0` can be factored
-as `X ⟶ I ⟶ 0` where `X ⟶ I` is a monomorphism and `I` is injective,
-i.e. `I ⟶ 0` has the right lifting property with respect to all monomorphisms.
+An abelian category $C$ is a Grothendieck abelian category if it satisfies certain axioms introduced
+in this paper: we assume that filtered colimits are exact and that there exists a generator $G$
+(any object in $C$ is a quotient of a coproduct of copies of $G$).
+Under these assumptions, we would like to show that $C$ has enough injectives, which means
+that any object $X$ of $C$ embeds into an injective object $I$.
+In other words, we would like to show that the morphism $X \to 0$ can be factored
+as $X \to I \to 0$ where $X \to I$ is a monomorphism and $I$ is injective,
+i.e. $I \to 0$ has the right lifting property with respect to all monomorphisms.
 
 This result is a consequence of the small object argument. Indeed, we construct a set of morphisms
-`generatingMonomorphisms G` (which consists of the inclusions of all subobjects of the generator `G`)
+`generatingMonomorphisms G` (which consists of the inclusions of all subobjects of the generator $G$)
 such that the right lifting property with respect to all monomorphisms is equivalent to the
 right lifting property with respect to this set `generatingMonomorphisms G`. It is quite technical
 to verify the assumptions that are required in order to apply the small object argument to this
-set of morphisms, but once we have it, we get the expected factorization `X ⟶ I ⟶ 0`
-where `I` is injective and `X ⟶ I` is a monomorphism (because monomorphisms are stable under
+set of morphisms, but once we have it, we get the expected factorization $X \to I \to 0$
+where $I$ is injective and $X \to I$ is a monomorphism (because monomorphisms are stable under
 pushouts and transfinite compositions).
 
 The formalization appears in the file
-[Abelian.GrothendieckCategory.EnoughInjectives](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.html)
+[`Abelian.GrothendieckCategory.EnoughInjectives`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.html)
 and it entered mathlib in [PR #20079](https://github.com/leanprover-community/mathlib4/pull/20079) after a series
 of pull requests by Joël Riou.
 
@@ -133,6 +139,8 @@ This result is also one of the key ingredients in the proof of the
 Freyd-Mitchell embedding theorem.
 
 # Freyd-Mitchell
+
+
 
 --[PR #22222](https://github.com/leanprover-community/mathlib4/pull/22222)
 

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -126,7 +126,7 @@ of pull requests by Joël Riou.
 The existence of enough injectives in Grothendieck abelian categories is an
 important tool in homological algebra. In particular, this applies to
 categories of abelian sheaves over a Grothendieck site, and in the future,
-it shall be used in order to construct right derived functors and to
+it shall be used in order to construct right derived functors and
 study cohomology theories.
 
 This result is also one of the key ingredients in the proof of the

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -249,7 +249,7 @@ prerequisites, so we spent a lot of time adding detailed results about presheave
 Kan extensions, comma categories and commutative group objects in cartesian monoidal categories to mathlib.
 
 While we were busy developing the theory of ind-objects, the development of the category of sheaves, which started in 2020, also continued. Over
-the years, many individuals have contributed to this development, including Bhavik Mehta, Adam Topaz, Jujian Zhang, Dagur Asgeirsson and Joël Riou.
+the years, many individuals have contributed to this development, including Bhavik Mehta, Adam Topaz, Jujian Zhang, Andrew Yang, Dagur Asgeirsson and Joël Riou.
 As of early 2025, this puts mathlib in the comfortable position of having all relevant results available for not one but two choices of $D$, and the
 fact that we are using the category of ind-objects is basically an arbitrary choice. Of course, categories of sheaves and ind-objects are both relevant
 for many reasons completely unrelated to the embedding theorem, so we are very happy to have this material in mathlib.

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -101,7 +101,7 @@ this result was generalized by Grothendieck.
 One of the results in the paper *Sur quelques points d'algèbre homologique* (*Tohoku Math. J.* (2), 9, 1957)
 by Alexander Grothendieck is that any Grothendieck abelian category has enough injectives.
 An abelian category `C` is a Grothendieck abelian category if it satisfies certain axioms introduced
-in the aformentioned paper: we assume that filtered colimits are exact and that there exists a generator `G`
+in this paper: we assume that filtered colimits are exact and that there exists a generator `G`
 (any object in `C` is a quotient of a coproduct of copies of `G`).
 Under these assumptions, we would like to show that `C` has enough injectives, which means
 that any object `X` of `C` embeds into an injective object `I`.

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -217,7 +217,7 @@ There are several candidates for $D$ which appear in the literature.
 * Freyd's *Abelian Categories* takes $D$ to be the opposite of the category of left-exact functors from $C$ to the category of abelian groups.
 Properties of $D$ are established mostly using ad-hoc arguments. Note that it is not obvious that $D$ is abelian, since $D$ does not contain
 *all* functors from $C$ to $\mathsf{Ab}$.
-* The proof sketched in the stack project takes $D$ to be the opposite of a category of abelian sheaves for a certain Grothendieck topology which is
+* The proof sketched in the Stacks project takes $D$ to be the opposite of a category of abelian sheaves for a certain Grothendieck topology which is
 inspired by Bergman's refinements. Many properties of $D$ are proved by transporting them along the sheafification adjunction.
 * The proof given in Kashiwara and Schapira's *Categories and Sheaves* takes $D$ to be the opposite of the category of ind-objects of $C^{\mathsf{op}}$
 (this is the category of pro-objects of $C$). Here, we infer many properties from properties of the category of types.

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -55,12 +55,11 @@ i.e. when any morphism $A \to X$ can be extended to a morphism $B \to X$.
 
 The small object argument involves a "set" of morphisms $I$ in the category $C$.
 Under certain technical assumptions, which are packaged in a type class [`HasSmallObjectArgument I`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/SmallObject/Basic.html#CategoryTheory.MorphismProperty.HasSmallObjectArgument),
-any morphism $X \to Y$ in $C$ can be factored as $X \to Z \to Y$ where $Z \to Y$ has
-the right lifting property with respect to all the morphisms in $I$ and
-$X \to Z$ is a transfinite composition of morphisms that are built up from $I$
-in a certain way (technically, these morphisms are pushouts of coproducts
-of morphisms in $I$). Moreover, this factorization is functorial in the morphism
-$X \to Y$.
+any morphism $X \to Y$ in $C$ can be factored as $X \to Z \to Y$ where
+* $X \to Z$ is a transfinite composition of morphisms that are built up from $I$ (using coproducts and pushouts);
+* $Z \to Y$ has the right lifting property with respect to all the morphisms in $I$.
+
+Moreover, this factorization is functorial in the morphism $X \to Y$.
 
 The basic construction for the small object argument is as follows. If $X \to Y$
 is a morphism, and $I$ is a family of morphisms $f_i : A_i \to B_i$, we consider all

--- a/posts/abelian-categories.md
+++ b/posts/abelian-categories.md
@@ -82,7 +82,7 @@ we may not necessarily get a lifting `B i ⟶ X`, but at least, we obtain a taut
 Then, the idea is to iterate this construction (applying it again to the morphism `Z ⟶ Y`, etc.)
 and pass to the colimit. Iterating over the natural numbers `ℕ` is not always enough:
 we actually need to do transfinite induction over a suitably chosen ordinal.
-The most significant part of the formalization was about such constructions by transfinite induction
+The most significant part of the formalization was about constructions by transfinite induction
 in categories, and in order to phrase certain result the structure
 [TransfiniteCompositionOfShape](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.html#CategoryTheory.TransfiniteCompositionOfShape) expressing that a morphism
 is a transfinite composition played an important role.


### PR DESCRIPTION
This post discusses recent additions to mathlib: the existence of enough injectives in Grothendieck abelian categories and the Freyd-Mitchell embedding theorem.
