### PR TITLE
fix bulleted lists in simprocs blog post

### DIFF
--- a/posts/simprocs-for-the-working-mathematician.md
+++ b/posts/simprocs-for-the-working-mathematician.md
@@ -90,7 +90,7 @@ Indeed, the equality `x = a` could be hidden arbitrarily deep inside the `∧`.
 When presented with a left hand side of the form `∃ x, P x`, where `P x` is of the form `_ ∧ ... ∧ _`, `existsAndEq` does the following:
 
 - Recursively traverse `P x` inside the existential quantifier looking for an equality `x = a` for some `a`.
-- If an equality is found, construct a proof that `∀ x, p x → x = a`.
+- If an equality is found, construct a proof that `∀ x, P x → x = a`.
 - Return the right hand side `P a` together with the proof obtained from the following lemma:
   ```lean
   lemma exists_of_imp_eq {α : Sort u} {p : α → Prop} (a : α) (h : ∀ x, p x → x = a) :


### PR DESCRIPTION
Right now the bulleted lists aren't rendered properly, since extra line breaks seem to be needed in Nikola's variant of markdown 🤷

<img width="730" alt="Screenshot 2025-05-26 at 5 03 06 PM" src="https://github.com/user-attachments/assets/3f14f32f-0b73-42d1-8d12-2a3de8131318" />