### PR TITLE
run build hourly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches-ignore:
       - 'deploy'
-  # schedule:
-  #   - cron: '0 4 * * *'
+  schedule:
+    - cron: '4 * * * *'
 
 jobs:
   build:
     name: Build HTML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.9
 
@@ -27,6 +27,5 @@ jobs:
         env:
           git_hash: ${{ github.sha }}
           DEPLOY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # DEPLOY_GITHUB_USER: leanprover-community-bot
           github_repo: ${{ github.repository }}
           github_ref: ${{ github.ref  }}


### PR DESCRIPTION
This will allow scheduled posts to be deployed automatically.

Also pin workflow versions.