### PR TITLE
pin lxml to 5.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Yapsy==1.12.2
 Pygments==2.11.0
 doit==0.35.0
 Markdown==3.3.7
+lxml==5.4.0
 Jinja2
 pyphen
 typogrify


### PR DESCRIPTION
[The build seems to be failing](https://github.com/leanprover-community/blog/actions/runs/15908143322/job/44871331158) after https://github.com/lxml/lxml/releases/tag/lxml-6.0.0 was released.