### PR TITLE
Fix minor rendering issues

### DIFF
--- a/posts/modular_forms.md
+++ b/posts/modular_forms.md
@@ -26,11 +26,8 @@ At their most basic, modular forms are functions from the complex upper half pla
 
 For any 
 
-$$\gamma =
-\left(\begin{array}{cc} 
-a & b\\ 
-c & d
-\end{array}\right)
+$$
+\gamma = \begin{pmatrix} a & b \\\\ c & d \end{pmatrix}
 $$
 
 in $\mathrm{GL}_2(\mathbb{R})^+$ ( $2 \times 2$ matrices with real entries and positive determinant) the weight $k \in \mathbb{Z}$ action of $\gamma$ on $f : \mathbb{H} \to \mathbb{C}$ is given by $$(f \mid_k \gamma) (z):=\mathrm{det} (\gamma)^{k-1} (cz+d)^{-k} f\left ( \frac{az+b}{cz+d}\right ).$$ One easily checks that this defines a right action on this space of functions, known as the weight $k$ *slash action*.

--- a/posts/sphere-packing-1.md
+++ b/posts/sphere-packing-1.md
@@ -267,9 +267,10 @@ to work together to achieve our objective of creating a maintainable
 proof artefact that will be useful to the community.
 
 We would like to take this opportunity to thank all our contributors, human and AI, past, present and future, most notably:
-* David Loeffler, for valuable inputs and upstream contributions intended for this project
-* Gareth Ma, for developing and robustifying nearly all of the sphere packing infrastructure
-* Pietro Monticone, for helping set up our CI, website and project management infrastructure, important maintenance support, insightful inputs on human-AI collaboration, and several contributions to the actual formalisation, with and without Aristotle
-* David Renshaw, for valuable proof contributions, maintenance support, and review support for both human- and AI-contributions
+
+- David Loeffler, for valuable inputs and upstream contributions intended for this project
+- Gareth Ma, for developing and robustifying nearly all of the sphere packing infrastructure
+- Pietro Monticone, for helping set up our CI, website and project management infrastructure, important maintenance support, insightful inputs on human-AI collaboration, and several contributions to the actual formalisation, with and without Aristotle
+- David Renshaw, for valuable proof contributions, maintenance support, and review support for both human- and AI-contributions
 
 We would also like to express our sincere gratitude to all our supporters and well-wishers, including (but by no means limited to) [Jeremy Avigad](https://www.andrew.cmu.edu/user/avigad/), [Matthew Ballard](https://sc.edu/study/colleges_schools/artsandsciences/mathematics/our_people/directory/ballard_matthew.php), [Kevin Buzzard](https://profiles.imperial.ac.uk/k.buzzard), [Leo de Moura](https://leodemoura.github.io/), [Emily Riehl](https://emilyriehl.github.io/), the [Mathlib maintainers](https://leanprover-community.github.io/teams/maintainers.html), and the [Institute for Computer-Aided Reasoning in Mathematics](https://icarm.io/).


### PR DESCRIPTION
Fix the bullet point of the sphere packing post. Also I found that @CBirkbeck's modular form post does not render small matrix correctly - we need `\\\\` instead of `\\` for matrices. Checked this locally with nikola.